### PR TITLE
Add unit tests runner for Github Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,17 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Unit Tests
+        run: python -m unittest discover -s test


### PR DESCRIPTION
Me pareció que podía ser útil tener un action de Github a modo de CI ya que el repo tiene tests.

Los targets son a modo de sugerencia y resultan de lo que mejor me funcionó en mi experiencia basada en flujos de feature branches, pero definitivamente deberían matchear el flow que quieran implementar en en el repo.